### PR TITLE
DataProvider to support counting objects before actually fetching them. 

### DIFF
--- a/EMongoDataProvider.php
+++ b/EMongoDataProvider.php
@@ -127,6 +127,10 @@ class EMongoDataProvider extends CActiveDataProvider{
 	 * @see yii/framework/web/CActiveDataProvider::calculateTotalItemCount()
 	 */
 	public function calculateTotalItemCount(){
+		if(!$this->_cursor){
+			$criteria=$this->getCriteria();
+			$this->_cursor=$this->model->find(isset($criteria['condition']) && is_array($criteria['condition']) ? $criteria['condition'] : array());
+		}		
 		return $this->_cursor->count();
 	}
 


### PR DESCRIPTION
Currently, calling $dataprovider->count() before $dataprovider->getData() throws an exception!
