### PR TITLE
Using Yii's native CMap::mergeArray instead of custom

### DIFF
--- a/EMongoClient.php
+++ b/EMongoClient.php
@@ -291,38 +291,7 @@ class EMongoClient extends CApplicationComponent{
 	    }
 	    return new MongoID($id);
 	}
-
-	/**
-	 * Recursively merges two arrays. Most useful for scope criteria objects
-	 */
-	public function merge(){
-		if (func_num_args() < 2) {
-			throw new CDbException(Yii::t('yii',__FUNCTION__ .' needs two or more array arguments'));
-			return;
-		}
-		$arrays = func_get_args();
-		$merged = array();
-
-		while ($arrays) {
-			$array = array_shift($arrays);
-			if (!is_array($array)) {
-				throw new CDbException(Yii::t('yii',__FUNCTION__ .' encountered a non array argument'));
-				return;
-			}
-			if (!$array)
-				continue;
-			foreach ($array as $key => $value)
-				if (is_string($key))
-				if (is_array($value) && array_key_exists($key, $merged) && is_array($merged[$key]))
-				$merged[$key] = call_user_func(array($this,__FUNCTION__), $merged[$key], $value);
-			else
-				$merged[$key] = $value;
-			else
-				$merged[] = $value;
-		}
-		return $merged;
-	}
-
+	
 	/**
 	 * Set read preference on MongoClient
 	 * @param $pref

--- a/EMongoCriteria.php
+++ b/EMongoCriteria.php
@@ -27,10 +27,10 @@ class EMongoCriteria{
 
 	public function mergeWith($criteria){
 		if(isset($criteria['condition']) && is_array($criteria['condition']))
-			$this->condition = Yii::app()->monogdb->merge($this->condition, $criteria['condition']);
+			$this->condition = CMap::mergeArray($this->condition, $criteria['condition']);
 
 		if(isset($criteria['sort']) && is_array($criteria['sort']))
-			$this->sort = Yii::app()->monogdb->merge($this->condition, $criteria['sort']);
+			$this->sort = CMap::mergeArray($this->condition, $criteria['sort']);
 
 		if(isset($criteria['skip'])&& is_numeric($criteria['skip']))
 			$this->skip = $criteria['skip'];

--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -725,7 +725,7 @@ class EMongoDocument extends EMongoModel{
      * @param $newCriteria
      */
     public function mergeCriteria($oldCriteria, $newCriteria){
-		return $this->getDbConnection()->merge($oldCriteria, $newCriteria);
+		return CMap::mergeArray($oldCriteria, $newCriteria);
     }
 
     /**

--- a/tests/MongoClientTest.php
+++ b/tests/MongoClientTest.php
@@ -61,8 +61,7 @@ class MongoClientTest extends CTestCase{
 	}
 
 	function testArrayMerging(){
-		$mongo = Yii::app()->mongodb;
-		$a = $mongo->merge(array('a' => 1, 'b' => array('c' => 2)), array('a' => 1, 'b' => array('c' => 2, 'd' => 3)));
+		$a = CMap::mergeArray(array('a' => 1, 'b' => array('c' => 2)), array('a' => 1, 'b' => array('c' => 2, 'd' => 3)));
 		$this->assertTrue(isset($a['a'], $a['b'], $a['b']['c'], $a['b']['d']));
 	}
 


### PR DESCRIPTION
Hi, Yii has native function to merge two or more arrays, so I removed `merge()` function from EMongoClient and updated its usage to `CMap::mergeArray()`.
