### PR TITLE
EMongoDataProvider does not work if sort is not specified

### DIFF
--- a/EMongoDataProvider.php
+++ b/EMongoDataProvider.php
@@ -101,6 +101,9 @@ class EMongoDataProvider extends CActiveDataProvider{
 		if(($sort=$this->getSort())!==false)
 		{
 			$sort = $sort->getOrderBy();
+			if (!is_array($sort)) {
+				$sort = array($sort);
+			}
 			if(sizeof($sort)>0){
 				$this->_cursor->sort($sort);
 			}


### PR DESCRIPTION
EMongoDataProvider is broken now if you do not specify a sort order (commit 75d674c seems to be responsible).

In EMongoDataProvider class, on line 103, EMongoSort#getOrderBy is passing its result to EMongoCursor#sort (which expects an array). Problem is that EMongoSort#getOrderBy:73 would return the default order as string, which causes an error to be raised.
