### PR TITLE
Add count() function to EMongoDocument

### DIFF
--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -773,4 +773,13 @@ class EMongoDocument extends EMongoModel{
     public function trace($func){
     	Yii::trace(get_class($this).'.'.$func.'()','extensions.MongoYii.EMongoDocument');
     }
+
+    /**
+     * Counts the number of documents in this collection
+     * @param $criteria
+     */
+	public function count($criteria){
+		$this->trace(__FUNCTION__);
+		return $this->getCollection()->count($criteria->getCondition(), $criteria->getLimit(), $criteria->getSkip());
+	}
 }


### PR DESCRIPTION
Just added count() function to EMongoDocument, simple modify but it can help us easier to work with CPagination. Now if we want to use CPagination, we need to run find() then can use count().
