### PR TITLE
Fix for UNIX-dependency

### DIFF
--- a/EMongoClient.php
+++ b/EMongoClient.php
@@ -305,7 +305,7 @@ class EMongoClient extends CApplicationComponent{
 
 	    $ts = pack( 'N', $yourTimestamp );
 	    $m = substr( md5( gethostname()), 0, 3 );
-	    $pid = pack( 'n', posix_getpid() );
+	    $pid = pack( 'n', getmypid() );
 	    $trail = substr( pack( 'N', $inc++ ), 1, 3);
 
 	    $bin = sprintf("%s%s%s%s", $ts, $m, $pid, $trail);


### PR DESCRIPTION
While debugging MongoYii, i found the posix_getpid() call, which didn't work for Windows. I replaced the function call with php core functionality.
