### PR TITLE
Fixed EMongoDocument::search() with pre-defined lists as attributes

### DIFF
--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -727,7 +727,7 @@ class EMongoDocument extends EMongoModel{
 		foreach($this->getSafeAttributeNames() as $attribute){
 
 			$value = $this->{$attribute};
-			if($value !== null && $value !== ''){
+			if($value !== null && $value !== '' && count($value)){
 				if(is_array($value) || is_object($value)){
 					$query[$attribute] = $value;
 				}elseif(preg_match('/^(?:\s*(<>|<=|>=|<|>|=))?(.*)$/',$value,$matches)){


### PR DESCRIPTION
Currently, `EMongoDocument::search()` cannot handle list-attributes which are pre-defined in a model. For example in your test application in model `Article`, you pre-defined `likes` with `public $likes=array();`.

When using `search()` on a blank/new model, this empty array will be used as criteria to find entries with zero likes, which is not the preferred behaivour.

I added `count()` to the condition which always returns `1` on any non-countable variable (except its null) and doesn't add empty attributes to the critera query (since it would return 0). To find empty lists/attributes, one may use the [$exists](http://docs.mongodb.org/manual/reference/operator/exists/) query operator.
