### PR TITLE
Fix for method count without specifying $criteria but with the condition in defaultScope

### DIFF
--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -730,12 +730,16 @@ class EMongoDocument extends EMongoModel{
 	 * Count() allows you to count all the documents returned by a certain condition, it is analogous
 	 * to $db->collection->find()->count() and basically does exactly that...
 	 * @param EMongoCriteria|array $criteria
+	 * @return int
 	 */
 	public function count($criteria = array()){
 	    $this->trace(__FUNCTION__);
 
 	    // If we provide a manual criteria via EMongoCriteria or an array we do not use the models own DbCriteria
 	    $criteria = !empty($criteria) || $criteria instanceof EMongoCriteria ? $criteria : $this->getDbCriteria();
+		if (is_array($criteria) && isset($criteria['condition'])){
+			$criteria = $criteria['condition'];
+		}
 	    if($criteria instanceof EMongoCriteria)
 	        $criteria = $criteria->getCondition();
 	    return $this->getCollection()->find(isset($criteria) ? $criteria : array())->count();


### PR DESCRIPTION
...
    /**
     \* @return array
     */
    public function defaultScope()
    {
        return [
            'condition' => [
                'sameField' => true
            ]
        ];
    }
...

MyModel::model()->count();
