### PR TITLE
Fix №2 for method count without specifying $criteria but with the limit||skip||etc... in defaultScope

### DIFF
--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -879,9 +879,6 @@ class EMongoDocument extends EMongoModel{
 	 * @return array
 	 */
 	public function mergeDbCriteria($newCriteria){
-		if ($newCriteria instanceof EMongoCriteria){
-			$newCriteria = $newCriteria->toArray();
-		}
 		 return $this->_criteria=$this->mergeCriteria($this->getDbCriteria(), $newCriteria);
 	}
 
@@ -898,7 +895,7 @@ class EMongoDocument extends EMongoModel{
      * @param array $newCriteria
 	 * @return array
      */
-    public function mergeCriteria(array $oldCriteria, array $newCriteria){
+    public function mergeCriteria($oldCriteria, $newCriteria){
 		return CMap::mergeArray($oldCriteria, $newCriteria);
     }
 


### PR DESCRIPTION
If defaultScope or other scopes missing field condition but there are other fields (skip, limit, etc.), the request is not valid
