### PR TITLE
TimeStamp on Scenario

### DIFF
--- a/behaviors/EMongoTimestampBehaviour.php
+++ b/behaviors/EMongoTimestampBehaviour.php
@@ -132,5 +132,6 @@ class EMongoTimestampBehaviour extends CActiveRecordBehavior {
                                 return true;
                         }
                 }
+                return true;
         }
 }


### PR DESCRIPTION
If I do not want to change the editing time of the model under certain scenarios - you can specify the onstsenario.
This can be used for example to add a counter view the object.
