### PR TITLE
Add belongs_to relation type

### DIFF
--- a/EMongoModel.php
+++ b/EMongoModel.php
@@ -329,7 +329,7 @@ class EMongoModel extends CModel{
 
         if($relation[0] == 'belongs_to') {
             $pk = $this->{$relation[2]};
-            $fkey = isset($relation['on']) ? $this->{$relation['on']} : '_id';
+            $fkey = isset($relation['on']) ? $relation['on'] : '_id';
         } else {
 	    	$fkey = $relation[2];
 	    	$pk = isset($relation['on']) ? $this->{$relation['on']} : $this->getPrimaryKey();


### PR DESCRIPTION
Hi, i try realize BELONGS_TO relation type (analogue CActiveRecord::BELONGS_TO)
I have my doubts about the correctness. Can you help with the correction, if that is not

Example usage:

``` PHP
    public function relations()
    {
        return [
            'mainPhoto'=> ['belongs_to', 'Photo', 'main_photo_id'],
        ];
    }
```

``` JavaScript
> db.user.find().pretty()
{
        "_id" : ObjectId("528379b701c25e680800002c"),
        "role" : "registered",
        "main_photo_id" : ObjectId("5284e3a101c25ed008000032"),
}
```

``` JavaScript
> db.photo.find().pretty()
{
        "_id" : ObjectId("5284e3a101c25ed008000032"),
        "filename" : "76e0d7ef165812335fc022dd035391ca.jpg",
}
```
