### PR TITLE
fixed bug where casting int values stored as strings to real ints caused...

### DIFF
--- a/EMongoModel.php
+++ b/EMongoModel.php
@@ -244,12 +244,12 @@ class EMongoModel extends CModel{
 			$field_meta = isset($_meta[$name]) ? $_meta[$name] : array();
 			if($safeOnly){
 				if(isset($attributes[$name]))
-					$this->$name=!is_array($value) && preg_match('/^([0-9]|[1-9]{1}\d+)$/' /* Will only match real integers, unsigned */, $value) > 0
+					$this->$name=!is_array($value) && preg_match('/^([0-9]|[1-9]{1}\d{1,8})$/' /* Will only match real integers, unsigned, that can safely be cast to ints */, $value) > 0
 						&& (string)$value < '9223372036854775807' ? (int)$value : $value;
 				elseif($safeOnly)
 					$this->onUnsafeAttribute($name,$value);
 			}else{
-				$this->$name=!is_array($value) && preg_match('/^([0-9]|[1-9]{1}\d+)$$/' /* Will only match real integers, unsigned */, $value) > 0
+				$this->$name=!is_array($value) && preg_match('/^([0-9]|[1-9]{1}\d{1,8})$/' /* Will only match real integers, unsigned, that can safely be cast to ints */, $value) > 0
 					&& (string)$value < '9223372036854775807' ? (int)$value : $value;
 			}
 		}


### PR DESCRIPTION
... data corruption on systems that don't support large int values (e.g. if storing > 32 bit int on 32 bit system or > 64 bit on 64 bit system as string in DB to preserve large numbers)

now int-like strings will only be cast to int if they are positively under 32 bit
