### PR TITLE
resetScope for FindOne

### DIFF
--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -838,11 +838,11 @@ class EMongoDocument extends EMongoModel
 				$cache->set($cacheKey, array($record), $this->getDbConnection()->queryCachingDuration, $this->getDbConnection()->queryCachingDependency);
 			}
 		}
-		
+
+        $this->resetScope(false);
 		if($record === null){
 			return null;
 		}
-		$this->resetScope(false);
 		return $this->populateRecord($record, true, $project === array() ? false : true);
 	}
 


### PR DESCRIPTION
Hi, Sammaye. 
May be I'am missing something, but it seems that we should call resetScope before the return statement. 
In case, when a record isn't found by specified scopes - $record variable contains null. As result, provided scopes maintains in EmongoDocument static array $_models. For my case, it caused problems, because i'm using findOne many times with different scopes during one request. 
I didn't observe your extension well, and warry if this change will affect anything else.
Best regards, and thanks for cute and powerful extension
Arsen.
