### PR TITLE
Bug using a one-relation, MongoDBRef foreign key and the reference does not exists

### DIFF
--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -389,9 +389,10 @@ class EMongoDocument extends EMongoModel
 	 */
 	public function populateRecord($attributes, $callAfterFind = true, $partial = false)
 	{
-		if($attributes === false){
+		if($attributes === false || $attributes === null){
 			return null;
 		}
+		
 		$record = $this->instantiate($attributes);
 		$record->setScenario('update');
 		$record->setIsNewRecord(false);

--- a/EMongoModel.php
+++ b/EMongoModel.php
@@ -298,7 +298,7 @@ class EMongoModel extends CModel
 	 */
 	public function populateRecord($attributes, $runEvent = true)
 	{
-		if($attributes === false){
+		if($attributes === false || $attributes === null){
 			return null;
 		}
 		
@@ -404,10 +404,15 @@ class EMongoModel extends CModel
 				$result = array();
 				foreach($pk as $singleReference){
 					$row = $this->populateReference($singleReference, $cname);
-					if($row){
-						array_push($result, $row);
-					}
+					
+					// When $row does not exists it will return null. It will not add it to $result
+					array_push($result, $row);
 				}
+				
+				// When $row is null count($result) will be 0 and $result will be an empty array
+				// Because we are a one relation we want to return null when a row does not exists
+				// Currently it was returning an empty array
+				
 				if($relation[0] === 'one' && count($result) > 0){
 					$result = $result[0];
 				}


### PR DESCRIPTION
When using this relation an error occurs when `user` does not exists
` 'user' => array('one', 'User', '_id', 'on' => 'user_ref') ` (`user_ref` is MongoDbRef)

See comments in the code about the steps of why the error occurs.

The `populateReference` then calls the `populateRecord($attributes)`. However, MongoDbRef::get (http://php.net/manual/en/mongodbref.get.php) returns `null` instead of `false`. The `populateRecord` wants to read the attributes, but `$attributes` is `null` => crash
