### PR TITLE
Empty query error workaround

### DIFF
--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -1284,7 +1284,7 @@ class EMongoDocument extends EMongoModel
 		return Yii::app()->mongodb->command(array(
 			'distinct' => $this->collectionName(),
 			'key' => $key,
-			'query' => $query
+			'query' => $query ? $query : null
 		));
 	}
 


### PR DESCRIPTION
Workaround for MongoDB error "exception: The query for the distinct command must be a document but was a Array" that happens in some version.

Error reports:
https://jira.mongodb.org/browse/PHP-1427
https://jira.mongodb.org/browse/PHP-1459